### PR TITLE
Add AI assistant side panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,4 @@ main.build.js
 .DS_Store
 package-lock.json
 yarn.lock
-
-currentchanges.patch
+extensions/

--- a/index.html
+++ b/index.html
@@ -147,15 +147,40 @@
           data-label="newTabAction"
           tabindex="-1"
         ></button>
+        <button
+          id="ai-assistant-button"
+          class="navbar-action-button i carbon:chatbot"
+          data-label="openAI"
+          title="AI Assistant"
+          tabindex="-1"
+        ></button>
       </div>
-    </div>
+      </div>
 
-    <button
-      id="switch-task-button"
-      class="navbar-action-button theme-text-color windowDragHandle i"
-      data-label="viewTasks"
-      tabindex="-1"
-    >
+      <style>
+        #content-container {
+          display: flex;
+          height: calc(100vh - 40px);
+        }
+        #webviews {
+          flex: 1;
+        }
+        #ai-panel {
+          width: 0;
+          overflow: hidden;
+          transition: width 0.3s ease;
+        }
+        #ai-panel.open {
+          width: 300px;
+        }
+      </style>
+
+      <button
+        id="switch-task-button"
+        class="navbar-action-button theme-text-color windowDragHandle i"
+        data-label="viewTasks"
+        tabindex="-1"
+      >
       <svg
         version="1.1"
         viewBox="0.0 0.0 26.0 26.0"
@@ -192,20 +217,25 @@
 
     <div id="overlay"></div>
 
-    <div id="webviews">
-      <div id="leftArrowContainer" class="arrow-indicator">
-        <i id="leftArrow" class="i carbon:chevron-left"></i>
+    <div id="content-container">
+      <div id="webviews">
+        <div id="leftArrowContainer" class="arrow-indicator">
+          <i id="leftArrow" class="i carbon:chevron-left"></i>
+        </div>
+        <div id="rightArrowContainer" class="arrow-indicator">
+          <i id="rightArrow" class="i carbon:chevron-right"></i>
+        </div>
+        <img id="webview-placeholder" hidden aria-hidden="true" />
+        <div id="ntp-content">
+            <img id="ntp-background" hidden>
+            <div id="ntp-background-controls">
+              <button id="ntp-image-remove"><i class="i carbon:trash-can"></i></button>
+              <button id="ntp-image-picker"><i class="i carbon:camera"></i></button>
+            </div>
+        </div>
       </div>
-      <div id="rightArrowContainer" class="arrow-indicator">
-        <i id="rightArrow" class="i carbon:chevron-right"></i>
-      </div>
-      <img id="webview-placeholder" hidden aria-hidden="true" />
-      <div id="ntp-content">
-          <img id="ntp-background" hidden>
-          <div id="ntp-background-controls">
-            <button id="ntp-image-remove"><i class="i carbon:trash-can"></i></button>
-            <button id="ntp-image-picker"><i class="i carbon:camera"></i></button>
-          </div>
+      <div id="ai-panel">
+        <div id="ai-extension-root"></div>
       </div>
     </div>
 
@@ -346,5 +376,6 @@
     <!-- add scripts in Gruntfile.js -->
 
     <script src="dist/bundle.js"></script>
+    <script type="module" src="extensions/ai-assistant/entry.js"></script>
   </body>
 </html>

--- a/vite-react/src/AiPanel.tsx
+++ b/vite-react/src/AiPanel.tsx
@@ -1,0 +1,5 @@
+export default function AiPanel() {
+  return (
+    <div style={{ backgroundColor: 'red', width: '100%', height: '100%' }} />
+  )
+}

--- a/vite-react/src/index.tsx
+++ b/vite-react/src/index.tsx
@@ -1,0 +1,10 @@
+import { createRoot } from 'react-dom/client'
+import AiPanel from './AiPanel'
+
+const root = document.getElementById('ai-extension-root')!
+createRoot(root).render(<AiPanel />)
+
+const btn = document.getElementById('ai-assistant-button')
+btn?.addEventListener('click', () => {
+  document.getElementById('ai-panel')?.classList.toggle('open')
+})

--- a/vite-react/vite.config.ts
+++ b/vite-react/vite.config.ts
@@ -1,7 +1,15 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    outDir: '../extensions/ai-assistant',
+    emptyOutDir: true,
+    lib: {
+      entry: 'src/index.tsx',
+      formats: ['es'],
+      fileName: () => 'entry.js',
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- add `ai-assistant-button` to the tab bar
- add flex container with a collapsible right side panel
- expose mount point for the React extension and load it
- create simple React `AiPanel` and entry script
- configure Vite to build the extension output
- ignore built extensions

## Testing
- `npm run build` inside `vite-react`
- `npm test` *(fails: standard not installed due to failed `npm install`)*

------
https://chatgpt.com/codex/tasks/task_b_68767e4ae004832d8d77ad4e87f4b522