### PR TITLE
Add basic AI assistant panel

### DIFF
--- a/css/aiAssistant.css
+++ b/css/aiAssistant.css
@@ -1,0 +1,21 @@
+#ai-assistant-panel {
+  position: fixed;
+  top: 36px;
+  right: 0;
+  bottom: 0;
+  width: 300px;
+  background: red;
+  z-index: 2;
+}
+
+body:not(.ai-panel-open) #ai-assistant-panel {
+  display: none;
+}
+
+#webviews {
+  transition: margin-right 0.2s;
+}
+
+body.ai-panel-open #webviews {
+  margin-right: 300px;
+}

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 
     <link rel="stylesheet" href="dist/bundle.css" />
     <link rel="stylesheet" href="ext/icons/iconfont.css" />
+    <link rel="stylesheet" href="css/aiAssistant.css" />
   </head>
 
   <body>
@@ -147,6 +148,11 @@
           data-label="newTabAction"
           tabindex="-1"
         ></button>
+        <button
+          id="ai-assistant-button"
+          class="navbar-action-button"
+          tabindex="-1"
+        >AI</button>
       </div>
     </div>
 
@@ -208,6 +214,8 @@
           </div>
       </div>
     </div>
+
+    <div id="ai-assistant-panel"></div>
 
     <!-- findinpage ui -->
 
@@ -346,5 +354,6 @@
     <!-- add scripts in Gruntfile.js -->
 
     <script src="dist/bundle.js"></script>
+    <script src="vite-react/dist/assets/main.js"></script>
   </body>
 </html>

--- a/js/default.js
+++ b/js/default.js
@@ -145,6 +145,7 @@ require('windowControls.js').initialize()
 require('navbar/menuButton.js').initialize()
 
 require('navbar/addTabButton.js').initialize()
+require('navbar/aiAssistantButton.js').initialize()
 require('navbar/tabContextMenu.js').initialize()
 require('navbar/tabActivity.js').initialize()
 require('navbar/tabColor.js').initialize()

--- a/js/navbar/aiAssistantButton.js
+++ b/js/navbar/aiAssistantButton.js
@@ -1,0 +1,9 @@
+function initialize () {
+  var button = document.getElementById('ai-assistant-button')
+  if (!button) return
+  button.addEventListener('click', function () {
+    document.body.classList.toggle('ai-panel-open')
+  })
+}
+
+module.exports = { initialize }

--- a/vite-react/src/AiAssistantPanel.tsx
+++ b/vite-react/src/AiAssistantPanel.tsx
@@ -1,0 +1,5 @@
+export default function AiAssistantPanel() {
+  return (
+    <div style={{ height: '100%', background: 'red' }} />
+  )
+}

--- a/vite-react/src/App.tsx
+++ b/vite-react/src/App.tsx
@@ -1,35 +1,5 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import AiAssistantPanel from './AiAssistantPanel'
 
-function App() {
-  const [count, setCount] = useState(0)
-
-  return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+export default function App() {
+  return <AiAssistantPanel />
 }
-
-export default App

--- a/vite-react/src/main.tsx
+++ b/vite-react/src/main.tsx
@@ -3,8 +3,14 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-)
+const container =
+  document.getElementById('ai-assistant-panel') ||
+  document.getElementById('root')
+
+if (container) {
+  createRoot(container).render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  )
+}


### PR DESCRIPTION
## Summary
- add AI assistant button to the navbar
- show a red placeholder panel when clicking the button
- load a small React app into that panel

## Testing
- `npm test` *(fails: standard not found)*
- `npm install` *(fails: ENETUNREACH while fetching electron)*

------
https://chatgpt.com/codex/tasks/task_b_687681451070832dac331447e885eeee