### PR TITLE
Add basic AI assistant panel

### DIFF
--- a/DEVELOPMENTGUIDE.md
+++ b/DEVELOPMENTGUIDE.md
@@ -56,11 +56,11 @@ Welcome! This document explains how to contribute new features, agents, or UI co
 
 4. **Integrate Components in Min’s UI**
 
-   * In the target HTML file (e.g., `browser-ui/navbar/navbar.html`), add:
+   * In the target HTML file, add a mount point and reference the build output:
 
      ```html
-     <div id="my-react-root"></div>
-     <script src="../../vite-react/dist/assets/main.js"></script>
+     <div id="assistant-panel-react-root"></div>
+     <script src="vite-react/dist/assistant-panel.js"></script>
      ```
    * In your React entry point (`vite-react/src/main.tsx`), mount your component:
 

--- a/css/assistantPanel.css
+++ b/css/assistantPanel.css
@@ -1,0 +1,14 @@
+#assistant-panel {
+  position: absolute;
+  top: calc(36px + var(--control-space-top));
+  right: 0;
+  width: 300px;
+  bottom: 0;
+  background: red;
+  display: none;
+  z-index: 3;
+}
+
+body.assistant-panel-visible #assistant-panel {
+  display: block;
+}

--- a/index.html
+++ b/index.html
@@ -147,6 +147,11 @@
           data-label="newTabAction"
           tabindex="-1"
         ></button>
+        <button
+          id="assistant-button"
+          class="navbar-action-button"
+          tabindex="-1"
+        >AI</button>
       </div>
     </div>
 
@@ -207,6 +212,10 @@
             <button id="ntp-image-picker"><i class="i carbon:camera"></i></button>
           </div>
       </div>
+    </div>
+
+    <div id="assistant-panel">
+      <div id="assistant-panel-react-root"></div>
     </div>
 
     <!-- findinpage ui -->
@@ -346,5 +355,6 @@
     <!-- add scripts in Gruntfile.js -->
 
     <script src="dist/bundle.js"></script>
+    <script src="vite-react/dist/assistant-panel.js"></script>
   </body>
 </html>

--- a/js/default.js
+++ b/js/default.js
@@ -145,6 +145,7 @@ require('windowControls.js').initialize()
 require('navbar/menuButton.js').initialize()
 
 require('navbar/addTabButton.js').initialize()
+require('navbar/assistantButton.js').initialize()
 require('navbar/tabContextMenu.js').initialize()
 require('navbar/tabActivity.js').initialize()
 require('navbar/tabColor.js').initialize()

--- a/js/navbar/assistantButton.js
+++ b/js/navbar/assistantButton.js
@@ -1,0 +1,33 @@
+var webviews = require('webviews.js')
+
+var assistantButton = document.getElementById('assistant-button')
+var panel = document.getElementById('assistant-panel')
+var panelWidth = 300
+
+function show () {
+  if (panel.dataset.visible === 'true') return
+  panel.dataset.visible = 'true'
+  document.body.classList.add('assistant-panel-visible')
+  webviews.adjustMargin([0, panelWidth, 0, 0])
+}
+
+function hide () {
+  if (panel.dataset.visible !== 'true') return
+  panel.dataset.visible = 'false'
+  document.body.classList.remove('assistant-panel-visible')
+  webviews.adjustMargin([0, -panelWidth, 0, 0])
+}
+
+function toggle () {
+  if (panel.dataset.visible === 'true') {
+    hide()
+  } else {
+    show()
+  }
+}
+
+function initialize () {
+  assistantButton.addEventListener('click', toggle)
+}
+
+module.exports = { initialize, show, hide }

--- a/scripts/buildBrowserStyles.js
+++ b/scripts/buildBrowserStyles.js
@@ -20,6 +20,7 @@ const modules = [
   'css/passwordManager.css',
   'css/passwordCapture.css',
   'css/passwordViewer.css',
+  'css/assistantPanel.css',
   'node_modules/dragula/dist/dragula.min.css'
 ]
 

--- a/vite-react/src/AssistantPanel.tsx
+++ b/vite-react/src/AssistantPanel.tsx
@@ -1,0 +1,6 @@
+export default function AssistantPanel () {
+  return (
+    <div style={{ width: '100%', height: '100%', background: 'red' }} />
+  )
+}
+

--- a/vite-react/src/main.tsx
+++ b/vite-react/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import App from './App.tsx'
+import AssistantPanel from './AssistantPanel'
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-)
+const container = document.getElementById('assistant-panel-react-root')
+if (container) {
+  createRoot(container).render(
+    <StrictMode>
+      <AssistantPanel />
+    </StrictMode>,
+  )
+}

--- a/vite-react/vite.config.ts
+++ b/vite-react/vite.config.ts
@@ -4,4 +4,13 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      output: {
+        entryFileNames: 'assistant-panel.js',
+        chunkFileNames: 'assets/[name].js',
+        assetFileNames: 'assets/[name][extname]'
+      }
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- create blank assistant panel React component
- add assistant button to tab bar
- wire up new button and panel with JS and styles
- expose panel build output via vite config
- document how to integrate React widgets

## Testing
- `npm test` *(fails: standard not found)*

------
https://chatgpt.com/codex/tasks/task_b_687681451070832dac331447e885eeee