### PR TITLE
Add resizable assistant panel

### DIFF
--- a/css/assistantPanel.css
+++ b/css/assistantPanel.css
@@ -7,6 +7,17 @@
   background: red;
   display: none;
   z-index: 3;
+  border-left: 1px solid #999;
+}
+
+#assistant-panel-resizer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 4px;
+  bottom: 0;
+  cursor: ew-resize;
+  background: transparent;
 }
 
 body.assistant-panel-visible #assistant-panel {

--- a/index.html
+++ b/index.html
@@ -215,6 +215,7 @@
     </div>
 
     <div id="assistant-panel">
+      <div id="assistant-panel-resizer"></div>
       <div id="assistant-panel-react-root"></div>
     </div>
 

--- a/js/navbar/assistantButton.js
+++ b/js/navbar/assistantButton.js
@@ -2,7 +2,11 @@ var webviews = require('webviews.js')
 
 var assistantButton = document.getElementById('assistant-button')
 var panel = document.getElementById('assistant-panel')
+var resizer = document.getElementById('assistant-panel-resizer')
 var panelWidth = 300
+var isResizing = false
+var startX = 0
+var startWidth = 0
 
 function show () {
   if (panel.dataset.visible === 'true') return
@@ -26,8 +30,35 @@ function toggle () {
   }
 }
 
+function onMouseMove (e) {
+  if (!isResizing) return
+  var newWidth = Math.max(150, startWidth + (startX - e.clientX))
+  if (newWidth !== panelWidth) {
+    panel.style.width = newWidth + 'px'
+    webviews.adjustMargin([0, newWidth - panelWidth, 0, 0])
+    panelWidth = newWidth
+  }
+}
+
+function onMouseUp () {
+  if (!isResizing) return
+  isResizing = false
+  document.removeEventListener('mousemove', onMouseMove)
+  document.removeEventListener('mouseup', onMouseUp)
+}
+
 function initialize () {
   assistantButton.addEventListener('click', toggle)
+  if (resizer) {
+    resizer.addEventListener('mousedown', function (e) {
+      isResizing = true
+      startX = e.clientX
+      startWidth = panelWidth
+      document.addEventListener('mousemove', onMouseMove)
+      document.addEventListener('mouseup', onMouseUp)
+      e.preventDefault()
+    })
+  }
 }
 
 module.exports = { initialize, show, hide }


### PR DESCRIPTION
## Summary
- make the assistant panel resizable with a drag handle

## Testing
- `npm test` *(fails: standard not found)*

------
https://chatgpt.com/codex/tasks/task_b_687684a6ede4832d8e0b6ffece575446