### PR TITLE
Add resizable assistant side panel

### DIFF
--- a/css/assistantPanel.css
+++ b/css/assistantPanel.css
@@ -2,11 +2,20 @@
   position: absolute;
   top: calc(36px + var(--control-space-top));
   right: 0;
-  width: 300px;
+  width: var(--assistant-panel-width, 300px);
   bottom: 0;
   background: red;
   display: none;
   z-index: 3;
+}
+
+#assistant-panel-resizer {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  cursor: ew-resize;
 }
 
 body.assistant-panel-visible #assistant-panel {

--- a/index.html
+++ b/index.html
@@ -215,6 +215,7 @@
     </div>
 
     <div id="assistant-panel">
+      <div id="assistant-panel-resizer"></div>
       <div id="assistant-panel-react-root"></div>
     </div>
 

--- a/js/navbar/assistantButton.js
+++ b/js/navbar/assistantButton.js
@@ -3,11 +3,17 @@ var webviews = require('webviews.js')
 var assistantButton = document.getElementById('assistant-button')
 var panel = document.getElementById('assistant-panel')
 var panelWidth = 300
+var MIN_WIDTH = 200
+var resizer = document.getElementById('assistant-panel-resizer')
+var isResizing = false
+var startX
+var startWidth
 
 function show () {
   if (panel.dataset.visible === 'true') return
   panel.dataset.visible = 'true'
   document.body.classList.add('assistant-panel-visible')
+  panel.style.setProperty('--assistant-panel-width', panelWidth + 'px')
   webviews.adjustMargin([0, panelWidth, 0, 0])
 }
 
@@ -15,6 +21,7 @@ function hide () {
   if (panel.dataset.visible !== 'true') return
   panel.dataset.visible = 'false'
   document.body.classList.remove('assistant-panel-visible')
+  panel.style.removeProperty('--assistant-panel-width')
   webviews.adjustMargin([0, -panelWidth, 0, 0])
 }
 
@@ -28,6 +35,40 @@ function toggle () {
 
 function initialize () {
   assistantButton.addEventListener('click', toggle)
+
+  if (resizer) {
+    resizer.addEventListener('mousedown', function (e) {
+      isResizing = true
+      startX = e.clientX
+      startWidth = panelWidth
+      e.preventDefault()
+    })
+
+    window.addEventListener('mousemove', function (e) {
+      if (!isResizing) return
+      var newWidth = startWidth + (startX - e.clientX)
+      if (newWidth < MIN_WIDTH) {
+        hide()
+        isResizing = false
+        panelWidth = MIN_WIDTH
+        return
+      }
+      var diff = newWidth - panelWidth
+      if (diff !== 0) {
+        panelWidth = newWidth
+        panel.style.setProperty('--assistant-panel-width', newWidth + 'px')
+        if (panel.dataset.visible === 'true') {
+          webviews.adjustMargin([0, diff, 0, 0])
+        }
+      }
+    })
+
+    window.addEventListener('mouseup', function () {
+      if (isResizing) {
+        isResizing = false
+      }
+    })
+  }
 }
 
 module.exports = { initialize, show, hide }


### PR DESCRIPTION
## Summary
- allow changing assistant panel width
- add draggable resizer
- hide panel when dragging below minimum width

## Testing
- `npm test` *(fails: standard not found)*

------
https://chatgpt.com/codex/tasks/task_b_687684a6ede4832d8e0b6ffece575446