### PR TITLE
Add resizable AI assistant panel

### DIFF
--- a/css/assistant.css
+++ b/css/assistant.css
@@ -1,0 +1,25 @@
+#assistant-panel {
+  position: fixed;
+  top: calc(36px + var(--control-space-top));
+  bottom: 0;
+  right: 0;
+  display: none;
+  height: calc(100vh - 36px - var(--control-space-top));
+}
+#assistant-panel.visible {
+  display: block;
+}
+#assistant-resizer {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 4px;
+  cursor: ew-resize;
+  height: 100%;
+  background: transparent;
+}
+
+.navbar-right-actions #assistant-button {
+  width: 36px;
+  font-size: 1.2em;
+}

--- a/index.html
+++ b/index.html
@@ -147,6 +147,12 @@
           data-label="newTabAction"
           tabindex="-1"
         ></button>
+        <button
+          id="assistant-button"
+          class="navbar-action-button"
+          tabindex="-1"
+          title="AI Assistant"
+        >AI</button>
       </div>
     </div>
 
@@ -207,6 +213,11 @@
             <button id="ntp-image-picker"><i class="i carbon:camera"></i></button>
           </div>
       </div>
+    </div>
+
+    <div id="assistant-panel">
+      <div id="assistant-resizer"></div>
+      <div id="assistant-root"></div>
     </div>
 
     <!-- findinpage ui -->
@@ -346,5 +357,6 @@
     <!-- add scripts in Gruntfile.js -->
 
     <script src="dist/bundle.js"></script>
+    <script src="vite-react/dist/assets/index-9_sxcfan.js"></script>
   </body>
 </html>

--- a/js/assistantPanel.js
+++ b/js/assistantPanel.js
@@ -1,0 +1,62 @@
+var assistantButton = document.getElementById('assistant-button')
+var panel = document.getElementById('assistant-panel')
+var resizer = document.getElementById('assistant-resizer')
+var webviews = document.getElementById('webviews')
+
+var width = Number(localStorage.getItem('assistant-panel-width')) || 300
+var minWidth = 150
+var resizing = false
+
+function setWidth (w) {
+  width = w
+  localStorage.setItem('assistant-panel-width', w)
+  panel.style.width = w + 'px'
+  webviews.style.marginRight = w + 'px'
+  window.assistantWidth = w
+  if (window.renderAssistantSidebar) {
+    window.renderAssistantSidebar()
+  }
+}
+
+function showPanel () {
+  panel.classList.add('visible')
+  setWidth(width)
+}
+
+function hidePanel () {
+  panel.classList.remove('visible')
+  webviews.style.marginRight = ''
+}
+
+function togglePanel () {
+  if (panel.classList.contains('visible')) {
+    hidePanel()
+  } else {
+    showPanel()
+  }
+}
+
+function onMouseMove (e) {
+  if (!resizing) return
+  var newWidth = window.innerWidth - e.clientX
+  if (newWidth < minWidth) {
+    hidePanel()
+    return
+  }
+  setWidth(newWidth)
+}
+
+function onMouseUp () { resizing = false }
+
+function initialize () {
+  assistantButton.addEventListener('click', togglePanel)
+  resizer.addEventListener('mousedown', function (e) {
+    if (!panel.classList.contains('visible')) return
+    resizing = true
+    e.preventDefault()
+  })
+  window.addEventListener('mousemove', onMouseMove)
+  window.addEventListener('mouseup', onMouseUp)
+}
+
+module.exports = { initialize }

--- a/js/default.js
+++ b/js/default.js
@@ -167,6 +167,7 @@ require('sessionRestore.js').initialize()
 require('bookmarkConverter.js').initialize()
 require('newTabPage.js').initialize()
 require('macHandoff.js').initialize()
+require('assistantPanel.js').initialize()
 
 // default searchbar plugins
 

--- a/scripts/buildBrowserStyles.js
+++ b/scripts/buildBrowserStyles.js
@@ -20,6 +20,7 @@ const modules = [
   'css/passwordManager.css',
   'css/passwordCapture.css',
   'css/passwordViewer.css',
+  'css/assistant.css',
   'node_modules/dragula/dist/dragula.min.css'
 ]
 

--- a/vite-react/package.json
+++ b/vite-react/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-pro-sidebar": "^1.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/vite-react/src/AssistantSidebar.tsx
+++ b/vite-react/src/AssistantSidebar.tsx
@@ -1,0 +1,11 @@
+import { Sidebar } from 'react-pro-sidebar'
+import 'react-pro-sidebar/dist/css/styles.css'
+
+interface Props { width: number }
+
+export default function AssistantSidebar({ width }: Props) {
+  return (
+    <Sidebar width={`${width}px`} backgroundColor="red" rootStyles={{height:'100%'}}>
+    </Sidebar>
+  )
+}

--- a/vite-react/src/assistant.tsx
+++ b/vite-react/src/assistant.tsx
@@ -1,0 +1,17 @@
+import ReactDOM from 'react-dom/client'
+import AssistantSidebar from './AssistantSidebar'
+
+declare global {
+  interface Window { assistantWidth?: number; renderAssistantSidebar?: () => void }
+}
+
+const rootEl = document.getElementById('assistant-root') as HTMLElement
+const root = ReactDOM.createRoot(rootEl)
+
+function render() {
+  const width = window.assistantWidth || 300
+  root.render(<AssistantSidebar width={width} />)
+}
+
+window.renderAssistantSidebar = render
+render()


### PR DESCRIPTION
## Summary
- add `react-pro-sidebar` dependency for React components
- implement `AssistantSidebar` React widget
- wire sidebar button and panel in `index.html`
- manage panel visibility and width in new `assistantPanel.js`
- include assistant styles in build pipeline
- display the new AI button with text so it's visible

## Testing
- `npm run build` in `vite-react`
- `npm test` *(fails: standard not found)*
- `npm run buildBrowserStyles` *(fails: missing `dragula` dependency)*

------
https://chatgpt.com/codex/tasks/task_b_6877aa2fe68c832d92a1d18203afa23b